### PR TITLE
Add test object parameter reference

### DIFF
--- a/docs/js-delivery-test-object.md
+++ b/docs/js-delivery-test-object.md
@@ -90,7 +90,7 @@ Parameter | Description
 **css** <br> Type: *string* <br> *Optional* | Shared CSS for the test object that is applied to all recipes. <br>`JS format`: Expects a JS string of CSS styles. <br>`YAML format`: Expects a relative path to a CSS file.
 **divertTo** <br> Type: *string* <br> *Optional* | Enable divert mode to send all eligible traffic into a particular recipe's key.
 **id** <br> Type: *string* <br> *Required* | A canonical test object ID by which subjects' assignments are recorded against. 
-**js** <br> Type: *function* <br> *Required* | Shared JS for the test object that is applied to all recipes. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
+**js** <br> Type: *function/object* <br> *Optional* | Shared JS function or object for the test object that is applied to all recipes. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function/object.
 **name** <br> Type: *string* <br> *Required* | The name of the test object that's useful in tracking.
 **recipes** <br> Type: *object* <br> *Required* | An object containing the definition of available recipes.
 **sampleRate** <br> Type: *number* <br> *Required* | The percentage of traffic to assign into the experiment between 0 and 1 (where 1 is 100%)
@@ -101,7 +101,7 @@ Parameter | Description
 
 Parameter | Description
 --|--
-**{{recipeId}}** <br> Type: *string* <br> *Required* | The canonical key that references a test object within the cookies and preview URLs. E.g. A recipe ID of `a` would be accesible through a preview URL like: `https://www.example.com/?mojito_w12=a`
+**{{recipeId}}** <br> Type: *string* <br> *Required* | The canonical key that references a test object within the cookies and preview URLs. E.g. A `recipeID` of `a` would be accesible through a preview URL like: `https://www.example.com/?mojito_w12=a`
 
 ## Recipe objects sub-level
 

--- a/docs/js-delivery-test-object.md
+++ b/docs/js-delivery-test-object.md
@@ -1,0 +1,114 @@
+---
+id: js-delivery-test-object
+title: Test object parameter reference in Mojito JS Delivery
+sidebar_label: Test object parameters
+---
+
+The test object contains everything an experiment needs to run, including the trigger, tracking information and recipe code (or variants). When you pass all this information into the ```Mojito.addTest()``` function, Mojito will execute all the logic in your experiment based on its order of execution.
+
+## Example test objects in JS & YAML
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--JavaScript-->
+```js
+Mojito.addTest({
+    "id": "w12",
+    "name": "Example test",
+    "divertTo": "1",
+    "sampleRate": 1,
+    "state": "live",
+    "gaExperimentId": "dsdy2h872g7d32h782n2",
+    "trigger": function (testObject) {
+        if (document.location.pathname === "/") {
+            // Activate the test at DOM Content Loaded
+            Mojito.utils.domReady(testObject.activate);
+        }
+    },
+    "recipes": {
+        "0": {
+            "name": "control"
+        },
+        "1": {
+            "name": "treatment",
+            "js": function(testObject) {
+                alert("You're in an experiment...");
+            },
+            "css": "body{display:none;}"
+        }
+    }
+});
+```
+
+<!--YAML-->
+```yml
+id: w12
+name: Example test
+divertTo: "1"
+sampleRate: 1
+state: live
+gaExperimentId: dsdy2h872g7d32h782n2
+trigger: trigger.js
+recipes:
+    "0":
+        name: control
+    "1":
+        name: treatment
+        js: 1.js
+        css: 1.css
+```
+
+<!--YAML trigger.js-->
+```js
+function trigger(testObject) {
+    if (document.location.pathname === "/") {
+        // Activate the test at DOM Content Loaded
+        Mojito.utils.domReady(testObject.activate);
+    }
+}
+```
+
+<!--YAML 1.js-->
+```js
+function(testObject) {
+    alert("You're in an experiment...");
+}
+```
+
+<!--YAML 1.css-->
+```css
+body {
+    display:none;
+}
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+
+## Test object: Root level
+
+Parameter | Description
+--|--
+**css** <br> Type: *string* <br> *Optional* | Shared CSS for the test object that is applied to all recipes. <br>`JS format`: Expects a JS string of CSS styles. <br>`YAML format`: Expects a relative path to a CSS file.
+**divertTo** <br> Type: *string* <br> *Optional* | Enable divert mode to send all eligible traffic into a particular recipe's key.
+**id** <br> Type: *string* <br> *Required* | A canonical test object ID by which subjects' assignments are recorded against. 
+**js** <br> Type: *function* <br> *Required* | Shared JS for the test object that is applied to all recipes. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
+**name** <br> Type: *string* <br> *Required* | The name of the test object that's useful in tracking.
+**recipes** <br> Type: *object* <br> *Required* | An object containing the definition of available recipes.
+**sampleRate** <br> Type: *number* <br> *Required* | The percentage of traffic to assign into the experiment between 0 and 1 (where 1 is 100%)
+**state** <br> Type: *string* <br> *Required* | A test object's state. Can be either: <br> `live` - in the container, accepting traffic into the experiment <br>`staging` - built into the container but not accepting traffic without a preview URL <br>`inactive` - not parsed or built into the container
+**trigger** <br> Type: *function* <br> *Required* | A JavaScript function executed as soon as the test object is loaded and can be used to conditionally activate an experiment. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
+
+## Recipes object
+
+Parameter | Description
+--|--
+**{{recipeId}}** <br> Type: *string* <br> *Required* | The canonical key that references a test object within the cookies and preview URLs. E.g. A recipe ID of `a` would be accesible through a preview URL like: `https://www.example.com/?mojito_w12=a`
+
+## Recipe objects sub-level
+
+Parameter | Description
+--|--
+**css** <br> Type: *string* <br> *Optional* | CSS that is applied as soon as the subject is bucketed. <br>`JS format`: Expects a JS string of CSS styles. <br>`YAML format`: Expects a relative path to a CSS file.
+**js** <br> Type: *function* <br> *Optional* | A JavaScript function that runs as soon as a subject is assigned into the test. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
+**name** <br> Type: *string* <br> *Required* | The name of the recipe used in tracking & reporting.
+**sampleRate** <br> Type: *number* <br> *Optional* | Allows users to set the proportion of traffic allocated to each recipe. This property expects a value between `0` and `1` and requires all recipes' provided sample rates to add up to `1`.
+

--- a/docs/js-delivery-test-object.md
+++ b/docs/js-delivery-test-object.md
@@ -6,7 +6,7 @@ sidebar_label: Test object parameters
 
 The test object contains everything an experiment needs to run, including the trigger, tracking information and recipe code (or variants). When you pass all this information into the ```Mojito.addTest()``` function, Mojito will execute all the logic in your experiment based on its order of execution.
 
-## Example test objects in JS & YAML
+## Example test objects in `JS` & `YAML` formats
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--JavaScript-->
@@ -92,7 +92,7 @@ Parameter | Description
 **id** <br> Type: *string* <br> *Required* | A canonical test object ID by which subjects' assignments are recorded against. 
 **js** <br> Type: *function/object* <br> *Optional* | Shared JS function or object for the test object that is applied to all recipes. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function/object.
 **name** <br> Type: *string* <br> *Required* | The name of the test object that's useful in tracking.
-**recipes** <br> Type: *object* <br> *Required* | An object containing the definition of available recipes.
+[**recipes**](#recipes-object) <br> Type: *object* <br> *Required* | An object containing the definition of available recipes. [See object definition](#recipes-object)
 **sampleRate** <br> Type: *number* <br> *Required* | The percentage of traffic to assign into the experiment between 0 and 1 (where 1 is 100%)
 **state** <br> Type: *string* <br> *Required* | A test object's state. Can be either: <br> `live` - in the container, accepting traffic into the experiment <br>`staging` - built into the container but not accepting traffic without a preview URL <br>`inactive` - not parsed or built into the container
 **trigger** <br> Type: *function* <br> *Required* | A JavaScript function executed as soon as the test object is loaded and can be used to conditionally activate an experiment. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
@@ -101,7 +101,7 @@ Parameter | Description
 
 Parameter | Description
 --|--
-**{{recipeId}}** <br> Type: *string* <br> *Required* | The canonical key that references a test object within the cookies and preview URLs. E.g. A `recipeID` of `a` would be accesible through a preview URL like: `https://www.example.com/?mojito_w12=a`
+[**{{recipeId}}**](#recipe-objects-sub-level) <br> Type: *string* <br> *Required* | The canonical key that references a test object within the cookies and preview URLs. [See object definition](#recipe-objects-sub-level). E.g. A `recipeID` of `a` would be accesible through a preview URL like: `https://www.example.com/?mojito_w12=a`
 
 ## Recipe objects sub-level
 

--- a/docs/js-delivery-utilities.md
+++ b/docs/js-delivery-utilities.md
@@ -1,7 +1,7 @@
 ---
 id: js-delivery-utilities
 title: Utility functions in Mojito JS Delivery
-sidebar_label: Mojito Utilities
+sidebar_label: Utility functions
 ---
 
 We've baked a series of utility functions into Mojito which we think are handy for a wide range of experiments. We often encounter race conditions or are waiting for an element to exist before we can do something on the page. These utilities will allow you to overcome the majority of these issues.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -18,7 +18,14 @@
           "js-delivery-hosting-snippet"
         ]
       },
-      "js-delivery-utilities"
+      {
+        "type": "subcategory",
+        "label": "API reference",
+        "ids": [
+          "js-delivery-test-object",
+          "js-delivery-utilities"
+        ]
+      }
     ],
     "2. Snowplow Storage": [
       "snowplow-storage-intro",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -116,8 +116,8 @@ const siteConfig = {
   ],
 
   algolia: {
-    apiKey: 'bd8462d0cdd55b4d467567530818ee84',
-    indexName: 'mojito-docs',
+    apiKey: 'fb512391b69cbe072f0ed74c938f64bc',
+    indexName: 'mojito_mint_metrics',
     algoliaOptions: {} // Optional, if provided by Algolia
   },
 


### PR DESCRIPTION
Hey guys,

I documented the test object parameters. I'm not 100% sure about the functionality for shared JS/CSS though.

Does this seem accurate?:

## Test object: Root level

Parameter | Description
--|--
**css** <br> Type: *string* <br> *Optional* | Shared CSS for the test object that is applied to all recipes. <br>`JS format`: Expects a JS string of CSS styles. <br>`YAML format`: Expects a relative path to a CSS file.
**divertTo** <br> Type: *string* <br> *Optional* | Enable divert mode to send all eligible traffic into a particular recipe's key.
**id** <br> Type: *string* <br> *Required* | A canonical test object ID by which subjects' assignments are recorded against. 
**js** <br> Type: *function* <br> *Required* | Shared JS for the test object that is applied to all recipes. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.
**name** <br> Type: *string* <br> *Required* | The name of the test object that's useful in tracking.
**recipes** <br> Type: *object* <br> *Required* | An object containing the definition of available recipes.
**sampleRate** <br> Type: *number* <br> *Required* | The percentage of traffic to assign into the experiment between 0 and 1 (where 1 is 100%)
**state** <br> Type: *string* <br> *Required* | A test object's state. Can be either: <br> `live` - in the container, accepting traffic into the experiment <br>`staging` - built into the container but not accepting traffic without a preview URL <br>`inactive` - not parsed or built into the container
**trigger** <br> Type: *function* <br> *Required* | A JavaScript function executed as soon as the test object is loaded and can be used to conditionally activate an experiment. <br>`JS format`: Expects a valid JavaScript function on this key. <br>`YAML format`: Expects a relative path to a JS file with that function.

![localhost_3001_docs_js-delivery-test-object](https://user-images.githubusercontent.com/2361388/65956120-fe07f700-e48c-11e9-83a5-cbfc0884399d.png)

#3 
