### PR TITLE
Update headline on homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -37,7 +37,7 @@ class HomeSplash extends React.Component {
 
     const ProjectTitle = () => (
       <h2 className="projectTitle">
-        <small>{siteConfig.title} - {siteConfig.tagline}</small>
+        <small>A professional, open split testing stack for speed &amp; security</small>
       </h2>
     );
 


### PR DESCRIPTION
We don't have a lot of traffic, but based on the test between the old and new headline, this one is better:

<img width="1400" alt="Screen Shot 2019-12-07 at 3 11 36 pm" src="https://user-images.githubusercontent.com/2361388/70368870-6b5c5c00-1904-11ea-8081-6bf8002c28e6.png">

<img width="829" alt="Screen Shot 2019-12-07 at 3 14 02 pm" src="https://user-images.githubusercontent.com/2361388/70368871-6dbeb600-1904-11ea-84d0-3966b3d8ae46.png">

This hardcodes it.