### PR TITLE
Fix 404 links in js-delivery-api-execution-order

### DIFF
--- a/docs/js-delivery-api-execution-order.md
+++ b/docs/js-delivery-api-execution-order.md
@@ -39,9 +39,9 @@ We recommend delaying activation until the page is ready to be transformed, by u
 
  - [`Mojito.utils.domReady()`](js-delivery-utilities#mojitoutilsdomready)
  - [`Mojito.utils.waitForElement()`](js-delivery-utilities#mojitoutilswaitforelement)
- - [`Mojito.utils.waitUntil()`](/js-delivery-utilities#mojitoutilswaituntil)
+ - [`Mojito.utils.waitUntil()`](js-delivery-utilities#mojitoutilswaituntil)
 
-See [more utilities here](/js-delivery-utilities)
+See [more utilities here](js-delivery-utilities)
 
 
 ## Order of experiments inside your container


### PR DESCRIPTION
Couple of 404 Utilities links need fixing