### PR TITLE
Change link colours for extra contrast

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -33,3 +33,7 @@
 .mainContainer .paddingTop {
     padding-top: 0px !important;
 }
+
+a {
+    color: #337dd7;
+}


### PR DESCRIPTION
Current link colours are hard to distinguish in Docusaurus.

<img width="770" alt="Screen Shot 2020-02-03 at 10 16 44 pm" src="https://user-images.githubusercontent.com/2361388/73649075-15711e00-46d3-11ea-9ebf-2b81e2dc0392.png">

This PR makes them easier to spot:

<img width="803" alt="Screen Shot 2020-02-03 at 10 11 55 pm" src="https://user-images.githubusercontent.com/2361388/73649069-11450080-46d3-11ea-811c-069412fa1f1e.png">
